### PR TITLE
Update DeployTheNCAgent.ps1

### DIFF
--- a/DeployTheNCAgent/DeployTheNCAgent.ps1
+++ b/DeployTheNCAgent/DeployTheNCAgent.ps1
@@ -94,4 +94,4 @@ Else {
 }
 # Now that we've got the registration token for the specified customer, let's use it to install the Windows Agent
 Write-Host "Initiating the agent install."
-# Start-Process -NoNewWindow -FilePath "C:\Temp\WindowsAgentSetup.exe" -ArgumentList "/s /v`" /qn CUSTOMERID=$SpecifiedCustomerID CUSTOMERSPECIFIC=1 REGISTRATION_TOKEN=$RetrievedRegistrationToken SERVERPROTOCOL=HTTPS SERVERADDRESS=$serverHost SERVERPORT=443`""
+Start-Process -NoNewWindow -FilePath "C:\Temp\WindowsAgentSetup.exe" -ArgumentList "/s /v`" /qn CUSTOMERID=$SpecifiedCustomerID CUSTOMERSPECIFIC=1 REGISTRATION_TOKEN=$RetrievedRegistrationToken SERVERPROTOCOL=HTTPS SERVERADDRESS=$serverHost SERVERPORT=443`""


### PR DESCRIPTION
Removed the comment character on line 97, as there's no reason why the script should not kick off the install of the agent.

I (apparently) commented out line 97 in the last commit. I don't have a good reason why, and with that line commented out the script doesn't actually install the agent. Feels like bad mojo.