### PR TITLE
Update get-log4jrcevulnerability.ps1

### DIFF
--- a/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
+++ b/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
@@ -57,7 +57,7 @@ if ($log4jfilescan -eq $null) {
 }
 else {
     Write-Host "Determining whether any of the $(($log4jfilenames).count) found .jar files are vulnerable to CVE-2021-44228 due to being capable of JNDI lookups..." -ForegroundColor Yellow
-    $log4jvulnerablefiles = $log4jfilescan | foreach-object {select-string "JndiLookup.class" $_} | select-object -exp Path | sort-object -unique
+    $log4jvulnerablefiles = $log4jfilescan | foreach-object {select-string "JndiLookup.class" $_ -ea 0} | select-object -exp Path | sort-object -unique
     $log4jvulnerablefilecount = ($log4jvulnerablefiles).count
     if ($log4jvulnerablefiles -eq $null) {
         $log4jvulnerable = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') OK - 0 Vulnerable JAR files were found"


### PR DESCRIPTION
if there are files you can enumerate but not read, it fails with an error opening these files. adding an extra -ea 0 solves this.