### PR TITLE
Update get-log4jrcevulnerability.ps1

### DIFF
--- a/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
+++ b/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
@@ -35,7 +35,7 @@ else {
         $robocopyexitcode = (start-process robocopy  -argumentlist "c:\ c:\DOESNOTEXIST *.jar /S /XJ /L /FP /NS /NC /NDL /NJH /NJS /r:0 /w:0 /LOG:$env:temp\log4jfilescan.csv" -wait).exitcode
         if ($? -eq $True) {
             $robocopycsv = $true
-            $log4jfilescan = import-csv "$env:temp\log4jfilescan.csv" -header FilePath        
+            $log4jfilescan = import-csv "$env:temp\log4jfilescan.csv" -header FilePath -Delimiter '?'    
             $log4jfilenames = $log4jfilescan
         }
     }


### PR DESCRIPTION
Fixes importing the robocopy results by using a delimiter that can't be in file or folder paths.
Import-CSV still imports each line separately.

Resolves Issue #27 