### PR TITLE
Exclude patched log4j jar file from report

### DIFF
--- a/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
+++ b/Vulnerability - CVE-2021-44228 (Log4j)/get-log4jrcevulnerability.ps1
@@ -79,7 +79,7 @@ else {
       if ($robocopycsv -eq $true) {
         $log4jvulnerablefiles = $log4jfilescan | foreach-object {
           if (($_.FilePath -ne $null) -and ($_.FilePath -ne "")) {
-            if (($_.FilePath -notmatch "placeholder.jar") -and ($_.FilePath -notmatch "spool\\drivers")) {
+            if (($_.FilePath -notmatch "placeholder.jar") -and ($_.FilePath -notmatch "spool\\drivers") -and ($_.FilePath -notmatch "log4j-core-2.16.0.jar")) {
               #write-host "CHECKING : " $_.FilePath -ForegroundColor Yellow
               select-string "JndiLookup.class" $_.FilePath
             }
@@ -89,7 +89,7 @@ else {
       else {
         $log4jvulnerablefiles = $log4jfilescan | foreach-object {
           if (($_.FilePath -ne $null) -and ($_.FilePath -ne "")) {
-            if ($_.FilePath -notmatch "placeholder.jar") {
+            if (($_.FilePath -notmatch "placeholder.jar") -and ($_.FilePath -notmatch "log4j-core-2.16.0.jar")) {
               #write-host "CHECKING : " $_ -ForegroundColor Yellow
               select-string "JndiLookup.class" $_
             }


### PR DESCRIPTION
The 2.16.0 version of log4j-core-2.16.0.jar is patched, this stops the script from reporting patched systems as vulnerable.